### PR TITLE
Fix conflicting backend dependencies

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -38,7 +38,7 @@ This will install the following dependencies:
 - Flask-Cors == 3.0.10
 - Pillow == 10.2.0
 - Werkzeug == 2.0
-- itsdangerous == 1.1.0
+- itsdangerous == 2.0
 - click == 7.1.2
 - Pandas == 2.0.1
 - piexif == 1.1.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@ Flask == 2.0.1
 Flask-Cors == 3.0.10
 Pillow == 10.2.0
 Werkzeug == 2.0
-itsdangerous==1.1.0
+itsdangerous==2.0
 click==7.1.2
 Typing
 Pandas == 2.0.1

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
**Problem:**
Installing backend dependencies failed due to conflicting dependencies when running `pip install -r requirements.txt`

**Error Message:**
```
ERROR: Cannot install -r requirements.txt and itsdangerous==1.1.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested itsdangerous==1.1.0
    flask 2.0.1 depends on itsdangerous>=2.0
```

**Solution:**
To resolve this conflict, I changed the dependency to `itsdangerous==2.0`
