### PR TITLE
Update environment variables using pathlib

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,15 +10,23 @@ import PIL.ExifTags as ExifTags
 import pandas as pd
 import logging
 import json
+from pathlib import Path
 
 app = Flask(__name__)
 CORS(app, resources={r"/*": {'origins': "*"}})
 
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
-DESTINATION_PATH = "E:/Research/Vue-Flusk/dnr/sample_images"
-RESULTS_PATH = "E:/Research/Vue-Flusk/dnr/Results"
-MODEL_PATH = 'E:/Research/Vue-Flusk/dnr/oak_wilt_demo2.h5'
-FEEDBACK_FILE_PATH = os.path.join(DESTINATION_PATH, 'feedback.json')
+BASE_DIR = Path(__file__).resolve().parent
+
+DESTINATION_PATH = BASE_DIR / 'dnr' / 'sample_images'
+RESULTS_PATH = BASE_DIR / 'dnr' / 'Results'
+MODEL_PATH = BASE_DIR.parent / 'oak_wilt_demo2.h5'
+
+# Create directories if they do not exist
+DESTINATION_PATH.mkdir(parents=True, exist_ok=True)
+RESULTS_PATH.mkdir(parents=True, exist_ok=True)
+
+FEEDBACK_FILE_PATH = DESTINATION_PATH / 'feedback.json'
 
 logging.basicConfig(level=logging.INFO)
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
**Problem:**
The original code has hardcoded environment variables with absolute paths specific to the developer's machine, making it incompatible with other operating systems. 

**Solution:**
To resolve this problem, I used `pathlib` to dynamically build file paths in a platform-independent way, ensuring compatibility across all operating systems. Additionally, directories are now automatically created if they do not already exist, making the setup more robust and portable. 